### PR TITLE
add new params, fix set temp in zone off

### DIFF
--- a/hass-actronque/AirConditionerData.cs
+++ b/hass-actronque/AirConditionerData.cs
@@ -13,8 +13,10 @@ namespace HMX.HASSActronQue
 		public double SetTemperatureCooling; // TemperatureSetpoint_Cool_oC
 		public double SetTemperatureHeating; // TemperatureSetpoint_Heat_oC
 		public double Temperature; // LiveTemp_oC
+		public double OutdoorTemperature; // LiveOutdoorTemp_oC
 		public double Humidity; // LiveHumidity_pc
 		public string CompressorState; // CompressorMode
+		public double CompressorCapacity; // CompressorCapacity
 		public DateTime LastUpdated;
 	}
 }

--- a/hass-actronque/AirConditionerZone.cs
+++ b/hass-actronque/AirConditionerZone.cs
@@ -11,5 +11,6 @@ namespace HMX.HASSActronQue
 		public double SetTemperatureCooling; // TemperatureSetpoint_Cool_oC
 		public double SetTemperatureHeating; // TemperatureSetpoint_Heat_oC
 		public bool State;
+		public double ZonePosition; // ZonePosition
 	}
 }


### PR DESCRIPTION
This Pull request addresses the 2 issues i raised.

https://github.com/MikeJMcGuire/hass-actronque/issues/4
Firstly, the correct set point is used if a zone is turned off (Whilst unit is still turned on), See line 1429 of Que.cs

And adds additional params i requested in https://github.com/MikeJMcGuire/hass-actronque/issues/3

